### PR TITLE
Використати addEventListener замість onclick

### DIFF
--- a/task6/script.js
+++ b/task6/script.js
@@ -13,18 +13,17 @@ class Notification {
     notification.className = `notification ${type}`;
     notification.innerHTML = `
             <span>${message}</span>
-            <button class="close-btn" onclick="this.parentElement.remove()">×</button>
+            <button class="close-btn">×</button>
         `;
+
+    const closeButton = notification.querySelector(".close-btn");
+    closeButton.addEventListener("click", () => notification.remove());
 
     this.container.appendChild(notification);
 
     if (autoClose) {
-      setTimeout(() => {
-        notification.remove();
-      }, duration);
+      setTimeout(() => notification.remove(), duration);
     }
-
-    notification.addEventListener("click", () => notification.remove());
   }
 }
 


### PR DESCRIPTION
Closes #1 
У поточному коді кнопка закриття сповіщення (`<button class="close-btn">×</button>`) використовує інлайн-обробник подій onclick, який напряму видаляє батьківський елемент:
`<button class="close-btn" onclick="this.parentElement.remove()">×</button>`

Використання onclick в HTML змішує розмітку та логіку, що ускладнює підтримку та розширення коду

Рішення:
змінити код

```
notification.innerHTML = `
            <span>${message}</span>
            <button class="close-btn" onclick="this.parentElement.remove()">×</button>
        `;
```

на

```
    notification.innerHTML = `
            <span>${message}</span>
            <button class="close-btn">×</button>
        `;

    const closeButton = notification.querySelector(".close-btn");
    closeButton.addEventListener("click", () => notification.remove());
```